### PR TITLE
Change key code for ctrl+enter detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
             // Use ctrl + enter to evaluate
             $("#textarea-main").keypress(function(e) {
             	var keyCode = e.keyCode || e.charCode || e.which;
-            	if (keyCode == 13 && e.ctrlKey) {
+            	if (keyCode == 10 && e.ctrlKey) {
             	    Alfeo();
             	}
             });


### PR DESCRIPTION
Orginally, I thought that the code would work if we detected the enter key plus the control key. Turns out that's not the case anymore, and ctrl+enter has it's own key code now.